### PR TITLE
add decatt to decision type and route to fetch it

### DIFF
--- a/src/modules/decisions/decisionType.ts
+++ b/src/modules/decisions/decisionType.ts
@@ -19,6 +19,7 @@ type decisionType = {
   chamberName: string;
   dateCreation: string;
   dateDecision: string;
+  decatt?: number[];
   jurisdictionCode: string;
   jurisdictionId: string;
   jurisdictionName: string;

--- a/src/modules/decisions/lib/generateDecision.ts
+++ b/src/modules/decisions/lib/generateDecision.ts
@@ -23,6 +23,7 @@ function generateDecision(decisionFields: Partial<decisionType> = {}): decisionT
     chamberName: `CHAMBER_NAME_${Math.random()}`,
     dateCreation: new Date().toISOString(),
     dateDecision: new Date().toISOString(),
+    decatt: undefined,
     jurisdictionCode: `JURISDICTION_CODE_${Math.random()}`,
     jurisdictionId: `JURISDICTION_ID_${Math.random()}`,
     jurisdictionName: `JURISDICTION_NAME_${Math.random()}`,

--- a/src/modules/decisions/repository/buildDecisionFakeRepository.ts
+++ b/src/modules/decisions/repository/buildDecisionFakeRepository.ts
@@ -67,6 +67,18 @@ async function buildDecisionFakeRepository(): Promise<decisionRepositoryType> {
       return result;
     },
 
+    async findBySourceIdAndSourceName(sourceId, sourceName) {
+      const result = collection.find(
+        (decision) => decision.sourceId === sourceId && decision.sourceName === sourceName,
+      );
+
+      if (!result) {
+        throw new Error(`No matching ${collectionName} for sourceId ${sourceId}`);
+      }
+
+      return result;
+    },
+
     async insert(decision) {
       collection.push(decision);
     },

--- a/src/modules/decisions/repository/buildDecisionRepository.ts
+++ b/src/modules/decisions/repository/buildDecisionRepository.ts
@@ -92,6 +92,18 @@ async function buildDecisionRepository(): Promise<decisionRepositoryType> {
       });
     },
 
+    async findBySourceIdAndSourceName(sourceId, sourceName) {
+      return runMongo(async ({ collection }) => {
+        const result = await collection.findOne({ sourceId, sourceName } as any);
+
+        if (!result) {
+          throw new Error(`No matching ${decisionCollectionName} for sourceId ${sourceId}`);
+        }
+
+        return result;
+      });
+    },
+
     async insert(decision) {
       await runMongo(({ collection }) => collection.insert(decision));
     },

--- a/src/modules/decisions/repository/decisionRepositoryType.ts
+++ b/src/modules/decisions/repository/decisionRepositoryType.ts
@@ -16,6 +16,10 @@ type decisionRepositoryType = {
   findAllIdsWithoutLabelFields: () => Promise<Array<decisionType['_id']>>;
   findById: (id: mongoIdType) => Promise<decisionType>;
   findByDecisionId: (decisionId: decisionType['sourceId']) => Promise<decisionType>;
+  findBySourceIdAndSourceName: (
+    sourceId: decisionType['sourceId'],
+    sourceName: decisionType['sourceName'],
+  ) => Promise<decisionType>;
   insert: (decision: decisionType) => Promise<void>;
   updateById: (id: mongoIdType, decisionField: Partial<decisionType>) => Promise<void>;
   updateByIds: (ids: mongoIdType[], decisionField: Partial<decisionType>) => Promise<void>;

--- a/src/modules/decisions/service/decisionService.spec.ts
+++ b/src/modules/decisions/service/decisionService.spec.ts
@@ -46,6 +46,22 @@ describe('decisionService', () => {
     });
   });
 
+  describe('fetchDecisionBySourceIdAndSourceName', () => {
+    it('should fetch the right decision', async () => {
+      const decisionRepository = await buildDecisionRepository();
+      const decisions = [
+        { sourceId: 100, sourceName: 'jurica' },
+        { sourceId: 200, sourceName: 'jurica' },
+        { sourceId: 200, sourceName: 'jurinet' },
+      ].map(generateDecision);
+      await Promise.all(decisions.map(decisionRepository.insert));
+
+      const fetchedDecision = await decisionService.fetchDecisionBySourceIdAndSourceName(200, 'jurica');
+
+      expect(fetchedDecision).toEqual(decisions[1]);
+    });
+  });
+
   describe('fetchPseudonymisationsToExport', () => {
     it(`should fetch all the pseudonymisation text and id of the decisions ready to be exported`, async () => {
       const decisionRepository = await buildDecisionRepository();

--- a/src/modules/decisions/service/decisionService.ts
+++ b/src/modules/decisions/service/decisionService.ts
@@ -12,6 +12,15 @@ const decisionService = {
     await decisionRepository.insert(decision);
   },
 
+  async fetchDecisionBySourceIdAndSourceName(
+    sourceId: decisionType['sourceId'],
+    sourceName: decisionType['sourceName'],
+  ) {
+    const decisionRepository = await buildDecisionRepository();
+
+    return decisionRepository.findBySourceIdAndSourceName(sourceId, sourceName);
+  },
+
   async fetchPseudonymisationsToExport() {
     const decisionRepository = await buildDecisionRepository();
 


### PR DESCRIPTION
The decatt type was added and contains an array of sourceIds.

The service fetchDecisionBySourceIdAndSourceName was added to help fetch decisions from jurica that have a specified sourceId