### PR TITLE
correct with falsy check

### DIFF
--- a/src/modules/decisions/lib/shouldBeTreatedByLabel.ts
+++ b/src/modules/decisions/lib/shouldBeTreatedByLabel.ts
@@ -3,5 +3,5 @@ import { decisionType } from '../decisionType';
 export { shouldBeTreatedByLabel };
 
 function shouldBeTreatedByLabel(decision: decisionType) {
-  return decision.labelStatus === 'toBeTreated' && decision.pseudoText === '';
+  return decision.labelStatus === 'toBeTreated' && !decision.pseudoText;
 }


### PR DESCRIPTION
The pseudo text are not only strings. It can also be null.

We check for falsy value in shouldBeTreatedByLabel