### PR TITLE
Sder jurinet jurica lib refacto

### DIFF
--- a/dist/lib/index.d.ts
+++ b/dist/lib/index.d.ts
@@ -1,0 +1,3 @@
+import { jurinetLib } from './jurinetLib';
+import { juricaLib } from './juricaLib';
+export { jurinetLib, juricaLib };

--- a/dist/lib/index.js
+++ b/dist/lib/index.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.juricaLib = exports.jurinetLib = void 0;
+var jurinetLib_1 = require("./jurinetLib");
+Object.defineProperty(exports, "jurinetLib", { enumerable: true, get: function () { return jurinetLib_1.jurinetLib; } });
+var juricaLib_1 = require("./juricaLib");
+Object.defineProperty(exports, "juricaLib", { enumerable: true, get: function () { return juricaLib_1.juricaLib; } });

--- a/dist/lib/juricaLib.d.ts
+++ b/dist/lib/juricaLib.d.ts
@@ -1,0 +1,4 @@
+export { juricaLib };
+declare const juricaLib: {
+    cleanText(text: string): string;
+};

--- a/dist/lib/juricaLib.js
+++ b/dist/lib/juricaLib.js
@@ -1,0 +1,28 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.juricaLib = void 0;
+var he_1 = require("he");
+var juricaLib = {
+    cleanText: function (text) {
+        if (typeof text !== 'string') {
+            throw new Error('juricaLib.cleanText: text must be a string.');
+        }
+        if (text === '') {
+            throw new Error('juricaLib.cleanText: empty text, the document could be malformed or corrupted.');
+        }
+        // Remove all HTML tags:
+        text = text.replace(/<\/?[^>]+(>|$)/gm, '');
+        // Handling newlines and carriage returns:
+        text = text.replace(/\r\n/gim, '\n');
+        text = text.replace(/\r/gim, '\n');
+        // Remove extra spaces:
+        text = text.replace(/\t/gim, '');
+        text = text.replace(/\\t/gim, ''); // That could happen...
+        text = text.replace(/\f/gim, '');
+        text = text.replace(/\\f/gim, ''); // That could happen too...
+        text = text.replace(/  +/gm, ' ').trim();
+        // Decode HTML entities:
+        return he_1.decode(text);
+    },
+};
+exports.juricaLib = juricaLib;

--- a/dist/lib/jurinetLib.d.ts
+++ b/dist/lib/jurinetLib.d.ts
@@ -1,0 +1,4 @@
+export { jurinetLib };
+declare const jurinetLib: {
+    cleanText(text: string): string;
+};

--- a/dist/lib/jurinetLib.js
+++ b/dist/lib/jurinetLib.js
@@ -1,0 +1,98 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.jurinetLib = void 0;
+var jurinetLib = {
+    cleanText: function (text) {
+        if (typeof text !== 'string') {
+            throw new Error('jurinetLib.cleanText: text must be a string.');
+        }
+        // There could be more than one <TEXTE_ARRET> tags, so we first split the text around them:
+        var fragments = text.split(/<\/?texte_arret>/gi);
+        if (fragments.length < 3) {
+            throw new Error('jurinetLib.cleanText: <TEXTE_ARRET> tag not found or incomplete, the document could be malformed or corrupted.');
+        }
+        // Keep this info for later:
+        var textNextToCatPub = text.indexOf('</CAT_PUB><TEXTE_ARRET>') !== -1;
+        // Remove all <TEXT_ARRET> fragments from the text:
+        text = text.replace(/<texte_arret>[\s\S]*<\/texte_arret>/gim, '');
+        // Cleaning every <TEXTE_ARRET> fragment:
+        var mergedText = [];
+        for (var j = 1; j < fragments.length - 1; j++) {
+            // Remove HTML tags:
+            // Note: we cannot perform the same global removing as the one
+            // we apply on Jurica texts, because Jurinet texts - which are
+            // not valid XML documents - can contain many unencoded and
+            // meaningful < or > characters (e.g. "<96>", "<< ... >>", etc.)
+            fragments[j] = fragments[j].replace(/<br\s*\/>/gim, '\r\n');
+            fragments[j] = fragments[j].replace(/<hr\s*\/>/gim, '\r\n');
+            fragments[j] = fragments[j].replace(/<a\s+[^>]+>/gim, '');
+            fragments[j] = fragments[j].replace(/<b\s+[^>]+>/gim, '');
+            fragments[j] = fragments[j].replace(/<i\s+[^>]+>/gim, '');
+            fragments[j] = fragments[j].replace(/<u\s+[^>]+>/gim, '');
+            fragments[j] = fragments[j].replace(/<em\s+[^>]+>/gim, '');
+            fragments[j] = fragments[j].replace(/<strong\s+[^>]+>/gim, '');
+            fragments[j] = fragments[j].replace(/<font\s+[^>]+>/gim, '');
+            fragments[j] = fragments[j].replace(/<span\s+[^>]+>/gim, '');
+            fragments[j] = fragments[j].replace(/<p\s+[^>]+>/gim, '');
+            fragments[j] = fragments[j].replace(/<h\d\s+[^>]+>/gim, '');
+            fragments[j] = fragments[j].replace(/<\/a>/gim, ' ');
+            fragments[j] = fragments[j].replace(/<\/b>/gim, ' ');
+            fragments[j] = fragments[j].replace(/<\/i>/gim, ' ');
+            fragments[j] = fragments[j].replace(/<\/u>/gim, ' ');
+            fragments[j] = fragments[j].replace(/<\/em>/gim, ' ');
+            fragments[j] = fragments[j].replace(/<\/strong>/gim, ' ');
+            fragments[j] = fragments[j].replace(/<\/font>/gim, ' ');
+            fragments[j] = fragments[j].replace(/<\/span>/gim, ' ');
+            fragments[j] = fragments[j].replace(/<\/p>/gim, '\r\n');
+            fragments[j] = fragments[j].replace(/<\/h\d>/gim, '\r\n');
+            // Handling newlines and carriage returns:
+            fragments[j] = fragments[j].replace(/\r\n/gim, '\n');
+            fragments[j] = fragments[j].replace(/\r/gim, '\n');
+            // Remove extra spaces:
+            fragments[j] = fragments[j].replace(/\t/gim, '');
+            fragments[j] = fragments[j].replace(/\\t/gim, ''); // That could happen...
+            fragments[j] = fragments[j].replace(/\f/gim, '');
+            fragments[j] = fragments[j].replace(/\\f/gim, ''); // That could happen too...
+            fragments[j] = fragments[j].replace(/  +/gm, ' ').trim();
+            // Minimal set of entities for XML validation:
+            fragments[j] = fragments[j]
+                .replace(/&/g, '&amp;')
+                .replace(/&amp;amp;/g, '&amp;')
+                .replace(/&amp;#/g, '&#');
+            fragments[j] = fragments[j].replace(/</g, '&lt;');
+            fragments[j] = fragments[j].replace(/>/g, '&gt;');
+            // Ignore empty fragment:
+            if (fragments[j] !== '') {
+                mergedText.push(fragments[j]);
+            }
+        }
+        if (mergedText.length === 0) {
+            throw new Error('jurinetLib.cleanText: empty text, the document could be malformed or corrupted.');
+        }
+        // Cleaning the rest of the text:
+        text = text
+            .replace(/&/g, '&amp;')
+            .replace(/&amp;amp;/g, '&amp;')
+            .replace(/&amp;#/g, '&#');
+        text = text.replace(/\s<\s/g, ' &lt; ');
+        text = text.replace(/\s>\s/g, ' &gt; ');
+        // A bad XML could lead to a bad JSON (the related data does not matter):
+        text = text.replace(/<\/numpourvoi><numpourvoi\s+id=\"\d+\">/gim, ',');
+        // Reinject the merged <TEXTE_ARRET> fragments:
+        if (textNextToCatPub === true) {
+            text = text
+                .replace('</CAT_PUB>', '</CAT_PUB><TEXTE_ARRET>' + mergedText.join(' ').trim() + '</TEXTE_ARRET>')
+                .trim();
+        }
+        else if (text.indexOf('</LIEN_WWW>') !== -1) {
+            text = text
+                .replace('</LIEN_WWW>', '</LIEN_WWW><TEXTE_ARRET>' + mergedText.join(' ').trim() + '</TEXTE_ARRET>')
+                .trim();
+        }
+        else {
+            throw new Error('jurinetLib.cleanText: End of <CAT_PUB> or <LIEN_WWW> tag not found, the document could be malformed or corrupted.');
+        }
+        return text;
+    },
+};
+exports.jurinetLib = jurinetLib;

--- a/dist/modules/decisions/lib/shouldBeTreatedByLabel.js
+++ b/dist/modules/decisions/lib/shouldBeTreatedByLabel.js
@@ -2,6 +2,6 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.shouldBeTreatedByLabel = void 0;
 function shouldBeTreatedByLabel(decision) {
-    return decision.labelStatus === 'toBeTreated' && decision.pseudoText === '';
+    return decision.labelStatus === 'toBeTreated' && !decision.pseudoText;
 }
 exports.shouldBeTreatedByLabel = shouldBeTreatedByLabel;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
+    "he": "^1.2.0",
     "lodash": "4.17.21",
     "mongodb": "^3.6.1"
   },
@@ -10,6 +11,7 @@
     "ts-jest": "^26.4.4",
     "@types/body-parser": "^1.19.0",
     "@types/express": "^4.17.8",
+    "@types/he": "^1.1.1",
     "@types/jest": "^26.0.13",
     "@types/lodash": "^4.14.168",
     "@types/mongodb": "^3.5.27",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,4 @@
+import { jurinetLib } from './jurinetLib';
+import { juricaLib } from './juricaLib';
+
+export { jurinetLib, juricaLib };

--- a/src/lib/juricaLib.ts
+++ b/src/lib/juricaLib.ts
@@ -1,6 +1,6 @@
-export { juricaLib };
-
 import { decode } from 'he';
+
+export { juricaLib };
 
 const juricaLib = {
   cleanText(text: string): string {

--- a/src/lib/juricaLib.ts
+++ b/src/lib/juricaLib.ts
@@ -1,0 +1,32 @@
+export { juricaLib };
+
+import { decode } from 'he';
+
+const juricaLib = {
+  cleanText(text: string): string {
+    if (typeof text !== 'string') {
+      throw new Error('juricaLib.cleanText: text must be a string.');
+    }
+
+    if (text === '') {
+      throw new Error('juricaLib.cleanText: empty text, the document could be malformed or corrupted.');
+    }
+
+    // Remove all HTML tags:
+    text = text.replace(/<\/?[^>]+(>|$)/gm, '');
+
+    // Handling newlines and carriage returns:
+    text = text.replace(/\r\n/gim, '\n');
+    text = text.replace(/\r/gim, '\n');
+
+    // Remove extra spaces:
+    text = text.replace(/\t/gim, '');
+    text = text.replace(/\\t/gim, ''); // That could happen...
+    text = text.replace(/\f/gim, '');
+    text = text.replace(/\\f/gim, ''); // That could happen too...
+    text = text.replace(/  +/gm, ' ').trim();
+
+    // Decode HTML entities:
+    return decode(text);
+  },
+};

--- a/src/lib/jurinetLib.ts
+++ b/src/lib/jurinetLib.ts
@@ -1,0 +1,112 @@
+export { jurinetLib };
+
+const jurinetLib = {
+  cleanText(text: string): string {
+    if (typeof text !== 'string') {
+      throw new Error('jurinetLib.cleanText: text must be a string.');
+    }
+
+    // There could be more than one <TEXTE_ARRET> tags, so we first split the text around them:
+    const fragments = text.split(/<\/?texte_arret>/gi);
+
+    if (fragments.length < 3) {
+      throw new Error(
+        'jurinetLib.cleanText: <TEXTE_ARRET> tag not found or incomplete, the document could be malformed or corrupted.',
+      );
+    }
+
+    // Keep this info for later:
+    const textNextToCatPub = text.indexOf('</CAT_PUB><TEXTE_ARRET>') !== -1;
+
+    // Remove all <TEXT_ARRET> fragments from the text:
+    text = text.replace(/<texte_arret>[\s\S]*<\/texte_arret>/gim, '');
+
+    // Cleaning every <TEXTE_ARRET> fragment:
+    const mergedText = [];
+    for (let j = 1; j < fragments.length - 1; j++) {
+      // Remove HTML tags:
+      // Note: we cannot perform the same global removing as the one
+      // we apply on Jurica texts, because Jurinet texts - which are
+      // not valid XML documents - can contain many unencoded and
+      // meaningful < or > characters (e.g. "<96>", "<< ... >>", etc.)
+      fragments[j] = fragments[j].replace(/<br\s*\/>/gim, '\r\n');
+      fragments[j] = fragments[j].replace(/<hr\s*\/>/gim, '\r\n');
+      fragments[j] = fragments[j].replace(/<a\s+[^>]+>/gim, '');
+      fragments[j] = fragments[j].replace(/<b\s+[^>]+>/gim, '');
+      fragments[j] = fragments[j].replace(/<i\s+[^>]+>/gim, '');
+      fragments[j] = fragments[j].replace(/<u\s+[^>]+>/gim, '');
+      fragments[j] = fragments[j].replace(/<em\s+[^>]+>/gim, '');
+      fragments[j] = fragments[j].replace(/<strong\s+[^>]+>/gim, '');
+      fragments[j] = fragments[j].replace(/<font\s+[^>]+>/gim, '');
+      fragments[j] = fragments[j].replace(/<span\s+[^>]+>/gim, '');
+      fragments[j] = fragments[j].replace(/<p\s+[^>]+>/gim, '');
+      fragments[j] = fragments[j].replace(/<h\d\s+[^>]+>/gim, '');
+      fragments[j] = fragments[j].replace(/<\/a>/gim, ' ');
+      fragments[j] = fragments[j].replace(/<\/b>/gim, ' ');
+      fragments[j] = fragments[j].replace(/<\/i>/gim, ' ');
+      fragments[j] = fragments[j].replace(/<\/u>/gim, ' ');
+      fragments[j] = fragments[j].replace(/<\/em>/gim, ' ');
+      fragments[j] = fragments[j].replace(/<\/strong>/gim, ' ');
+      fragments[j] = fragments[j].replace(/<\/font>/gim, ' ');
+      fragments[j] = fragments[j].replace(/<\/span>/gim, ' ');
+      fragments[j] = fragments[j].replace(/<\/p>/gim, '\r\n');
+      fragments[j] = fragments[j].replace(/<\/h\d>/gim, '\r\n');
+
+      // Handling newlines and carriage returns:
+      fragments[j] = fragments[j].replace(/\r\n/gim, '\n');
+      fragments[j] = fragments[j].replace(/\r/gim, '\n');
+
+      // Remove extra spaces:
+      fragments[j] = fragments[j].replace(/\t/gim, '');
+      fragments[j] = fragments[j].replace(/\\t/gim, ''); // That could happen...
+      fragments[j] = fragments[j].replace(/\f/gim, '');
+      fragments[j] = fragments[j].replace(/\\f/gim, ''); // That could happen too...
+      fragments[j] = fragments[j].replace(/  +/gm, ' ').trim();
+
+      // Minimal set of entities for XML validation:
+      fragments[j] = fragments[j]
+        .replace(/&/g, '&amp;')
+        .replace(/&amp;amp;/g, '&amp;')
+        .replace(/&amp;#/g, '&#');
+      fragments[j] = fragments[j].replace(/</g, '&lt;');
+      fragments[j] = fragments[j].replace(/>/g, '&gt;');
+
+      // Ignore empty fragment:
+      if (fragments[j] !== '') {
+        mergedText.push(fragments[j]);
+      }
+    }
+
+    if (mergedText.length === 0) {
+      throw new Error('jurinetLib.cleanText: empty text, the document could be malformed or corrupted.');
+    }
+
+    // Cleaning the rest of the text:
+    text = text
+      .replace(/&/g, '&amp;')
+      .replace(/&amp;amp;/g, '&amp;')
+      .replace(/&amp;#/g, '&#');
+    text = text.replace(/\s<\s/g, ' &lt; ');
+    text = text.replace(/\s>\s/g, ' &gt; ');
+
+    // A bad XML could lead to a bad JSON (the related data does not matter):
+    text = text.replace(/<\/numpourvoi><numpourvoi\s+id=\"\d+\">/gim, ',');
+
+    // Reinject the merged <TEXTE_ARRET> fragments:
+    if (textNextToCatPub === true) {
+      text = text
+        .replace('</CAT_PUB>', '</CAT_PUB><TEXTE_ARRET>' + mergedText.join(' ').trim() + '</TEXTE_ARRET>')
+        .trim();
+    } else if (text.indexOf('</LIEN_WWW>') !== -1) {
+      text = text
+        .replace('</LIEN_WWW>', '</LIEN_WWW><TEXTE_ARRET>' + mergedText.join(' ').trim() + '</TEXTE_ARRET>')
+        .trim();
+    } else {
+      throw new Error(
+        'jurinetLib.cleanText: End of <CAT_PUB> or <LIEN_WWW> tag not found, the document could be malformed or corrupted.',
+      );
+    }
+
+    return text;
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,6 +455,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/he@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/he/-/he-1.1.1.tgz#19e14033c4ee8f1a702c74dcc6182664839ac2b7"
+  integrity sha512-jpzrsR1ns0n3kyWt92QfOUQhIuJGQ9+QGa7M62rO6toe98woQjnsnzjdMtsQXCdvjjmqjS2ZBCC7xKw0cdzU+Q==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -2093,6 +2098,11 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hosted-git-info@^2.1.4:
   version "2.8.8"


### PR DESCRIPTION
To follow the work done in the https://github.com/Cour-de-cassation/sder/tree/sder_import_refactoring, I have extracted only the `jurinetLib` and `juricaLib` to merge it into the code base.

The next step is to add some test and refacto.